### PR TITLE
Improve comments handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,22 +46,22 @@
             "type": "object",
             "title": "VOCE Extension Configuration",
             "properties": {
-                "voce.echoFullIssue": {
+                "voce.echoFullGHIssue": {
                     "type": "boolean",
                     "default": true,
                     "description": "echo the full issue title and description in the chat."
                 },
-                "voce.echoIssueComments": {
+                "voce.echoGHIssueComments": {
                     "type": "boolean",
                     "default": true,
                     "description": "echo the comments of issue chat (only if echoFullIssue is also set)."
                 },
-                "voce.echoFullWorkItem": {
+                "voce.echoFullAzDWorkItem": {
                     "type": "boolean",
                     "default": true,
                     "description": "echo the full work item title and description in the chat."
                 },
-                "voce.echoWorkItemComments": {
+                "voce.echoAzDWorkItemComments": {
                     "type": "boolean",
                     "default": true,
                     "description": "echo the comments of work item chat (only if echoFullWorkItem is also set)."
@@ -81,7 +81,7 @@
                     "default": true,
                     "description": "echo the full pull request title and description in the chat."
                 },
-                "voce.echoGhPullRequestComments": {
+                "voce.echoGHPullRequestComments": {
                     "type": "boolean",
                     "default": true,
                     "description": "echo the comments of pull request chat (only if echoFullGhPullRequest is also set)."

--- a/src/azd/azDevOpsUtils.ts
+++ b/src/azd/azDevOpsUtils.ts
@@ -10,11 +10,11 @@ export function parseAzDevOpsValuesFromPrompt(
   const workItemMatch = request.prompt.match(workItemNumberRegex);
   
   let itemId = "";
-  let commentsUsage = "";
+  let commentsUsage = false;
   
   if (workItemMatch) {
     itemId = workItemMatch[1];
-    commentsUsage = workItemMatch[2];
+    commentsUsage = workItemMatch[2] === "+";
     stream.progress(`Work Item !${itemId} found in prompt.`);
   } 
 

--- a/src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx
+++ b/src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx
@@ -40,7 +40,6 @@ export class AzDevOpsPullrequestPrompt extends PromptElement<
     const echoPullRequestComments = config.get("echoAzDPullRequestComments", false) as boolean;
 
     if (echoFullPullRequest) {
-      const echoPullRequestComments = config.get("echoAzDPullRequestComments", false) as boolean;
       if (echoPullRequestComments) {
         const commentsString = azdoResult?.comments
           ? azdoResult.comments.map((comment: any) => `○ ${comment.body}`).join("\n\n")

--- a/src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx
+++ b/src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx
@@ -43,7 +43,7 @@ export class AzDevOpsPullrequestPrompt extends PromptElement<
       const echoPullRequestComments = config.get("echoAzDPullRequestComments", false) as boolean;
       if (echoPullRequestComments) {
         const commentsString = azdoResult?.comments
-          ? azdoResult.comments.map((comment: any) => comment.body).join("\n\n")
+          ? azdoResult.comments.map((comment: any) => `○ ${comment.body}`).join("\n\n")
           : "";
         
         StateFullAzDPrInStream(stream, {

--- a/src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx
+++ b/src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx
@@ -80,7 +80,7 @@ export class AzDevOpsPullrequestPrompt extends PromptElement<
       <>
         <AssistantMessage priority={300}>{ASSISTANT_MESSAGE}</AssistantMessage>
         <UserMessage priority={200}>
-          {`The pull request to work on has the title: "${azdoResult?.data?.fields["System.Title"]}" and the description: ${azdoResult?.data?.fields["System.Description"]}. Use that information to give better answer for the following user query.` +
+          {`The Azure DevOps pull request to work on has the title: "${azdoResult?.data?.fields["System.Title"]}" and the description: ${azdoResult?.data?.fields["System.Description"]}. Use that information to give better answer for the following user query.` +
             (azdoResult?.comments && azdoResult?.comments?.length > 0
               ? `Do also consider the comments: ${
                   azdoResult?.comments

--- a/src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx
+++ b/src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx
@@ -8,7 +8,7 @@ import {
 import { ASSISTANT_MESSAGE, OPEN_URL_COMMAND } from "../../consts";
 import {
   getAzdPullrequestById,
-  StateFullPrInStream,
+  StateFullAzDPrInStream,
 } from "./azDevOpsPullrequestFunctions";
 import { parseAzDevOpsValuesFromPrompt } from "../azDevOpsUtils";
 import type { AzDevOpsResult } from "../AzDevOpsResult";
@@ -37,13 +37,27 @@ export class AzDevOpsPullrequestPrompt extends PromptElement<
     // Access vscode settings
     const config = vscode.workspace.getConfiguration("voce");
     const echoFullPullRequest = config.get("echoFullAzDPullRequest", false) as boolean;
-    
+    const echoPullRequestComments = config.get("echoAzDPullRequestComments", false) as boolean;
+
     if (echoFullPullRequest) {
-      StateFullPrInStream(stream, {
-        title: azdoResult?.data?.fields["System.Title"] || "",
-        status: azdoResult?.data?.fields["System.State"] || "",
-        description: azdoResult?.data?.fields["System.Description"] || ""
-      });
+      const echoPullRequestComments = config.get("echoAzDPullRequestComments", false) as boolean;
+      if (echoPullRequestComments) {
+        const commentsString = azdoResult?.comments
+          ? azdoResult.comments.map((comment: any) => comment.body).join("\n\n")
+          : "";
+        
+        StateFullAzDPrInStream(stream, {
+          title: azdoResult?.data?.fields["System.Title"] || "",
+          status: azdoResult?.data?.fields["System.State"] || "",
+          description: azdoResult?.data?.fields["System.Description"] || "",
+        }, commentsString);
+      } else {
+        StateFullAzDPrInStream(stream, {
+          title: azdoResult?.data?.fields["System.Title"] || "",
+          status: azdoResult?.data?.fields["System.State"] || "",
+          description: azdoResult?.data?.fields["System.Description"] || ""
+        });
+      }
     } else {
       stream.markdown(
         `🔵PR [_${azdoResult.data?.fields["System.State"]}_]: **${azdoResult.data?.fields["System.Title"]}**\n\n`

--- a/src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx
+++ b/src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx
@@ -7,7 +7,7 @@ import {
 } from "@vscode/prompt-tsx";
 import { ASSISTANT_MESSAGE, OPEN_URL_COMMAND } from "../../consts";
 import {
-  getPullrequestById,
+  getAzdPullrequestById,
   StateFullPrInStream,
 } from "./azDevOpsPullrequestFunctions";
 import { parseAzDevOpsValuesFromPrompt } from "../azDevOpsUtils";
@@ -24,12 +24,12 @@ export class AzDevOpsPullrequestPrompt extends PromptElement<
     const { request, stream } = requestHandlerContext;
     const { azdoOrg, azdoProject, itemId, commentsUsage } = parseAzDevOpsValuesFromPrompt(request, stream);
 
-    const azdoResult = (await getPullrequestById(
+    const azdoResult = (await getAzdPullrequestById(
       requestHandlerContext,
       Number(itemId),
       azdoOrg,
       azdoProject,
-      commentsUsage === "+"
+      commentsUsage
     )) as AzDevOpsResult;
 
     stream.progress(`PR "${azdoResult?.data?.fields["System.Title"]}" loaded.`);
@@ -68,7 +68,7 @@ export class AzDevOpsPullrequestPrompt extends PromptElement<
         <UserMessage priority={200}>
           {`The pull request to work on has the title: "${azdoResult?.data?.fields["System.Title"]}" and the description: ${azdoResult?.data?.fields["System.Description"]}. Use that information to give better answer for the following user query.` +
             (azdoResult?.comments && azdoResult?.comments?.length > 0
-              ? `Do also regard the comments: ${
+              ? `Do also consider the comments: ${
                   azdoResult?.comments
                     ?.map((comment) => comment.body)
                     .join("\n\n")

--- a/src/azd/pullrequests/azDevOpsPullrequestFunctions.ts
+++ b/src/azd/pullrequests/azDevOpsPullrequestFunctions.ts
@@ -81,7 +81,7 @@ async function findRepositoryByRemoteUrl(
 }
 
 //get pull request object from Azure DevOps by its PR id
-export async function getPullrequestById(
+export async function getAzdPullrequestById(
   requestHandlerContext: RequestHandlerContext,
   pullRequestId: number,
   azdoOrg: string = "",

--- a/src/azd/pullrequests/azDevOpsPullrequestFunctions.ts
+++ b/src/azd/pullrequests/azDevOpsPullrequestFunctions.ts
@@ -10,12 +10,18 @@ import { type AzDevOpsComment } from "../AzDevOpsComment";
 import { type AzDevOpsResult } from "../AzDevOpsResult";
 import { PullRequestStatus } from "azure-devops-node-api/interfaces/GitInterfaces";
 
-export function StateFullPrInStream(
+export function StateFullAzDPrInStream(
   stream: vscode.ChatResponseStream,
-  pullrequest: { title: string; status:string; description: string }
+  pullrequest: { title: string; status:string; description: string },
+  comments: string = ""
 ) {
-  stream.markdown(`🔵PR [${pullrequest.status}]: **${pullrequest.title}**\n\n`);
+  stream.markdown(`🔵PR [_${pullrequest.status}_]: **${pullrequest.title}**\n\n`);
   stream.markdown(pullrequest.description?.replaceAll("\n", "\n> ") + "");
+  stream.markdown("\n\n");
+  if (comments && comments.length > 0) {
+    stream.markdown(`> **Comments:**\n\n`);
+    stream.markdown(comments.replaceAll("\n", "\n> ") + "");
+  }
   stream.markdown("\n\n----\n\n");
 }
 

--- a/src/azd/workitems/AzDevOpsWorkItemsPrompt.tsx
+++ b/src/azd/workitems/AzDevOpsWorkItemsPrompt.tsx
@@ -32,7 +32,7 @@ export class AzDevOpsWorkItemsPrompt extends PromptElement<
       Number(itemId),
       azdoOrg,
       azdoProject,
-      commentsUsage === "+"
+      commentsUsage
     )) as AzDevOpsResult;
 
     stream.progress(`🔷Work Item "${azdoResult?.data?.fields["System.Title"]}" loaded.`);

--- a/src/azd/workitems/AzDevOpsWorkItemsPrompt.tsx
+++ b/src/azd/workitems/AzDevOpsWorkItemsPrompt.tsx
@@ -39,8 +39,8 @@ export class AzDevOpsWorkItemsPrompt extends PromptElement<
 
     // Access vscode settings
     const config = vscode.workspace.getConfiguration("voce");
-    const echoFullWorkItem = config.get("echoFullWorkItem", false) as boolean;
-    const echoWorkItemComments = config.get("echoWorkItemComments", false) as boolean;
+    const echoFullWorkItem = config.get("echoFullAzDWorkItem", false) as boolean;
+    const echoWorkItemComments = config.get("echoAzDWorkItemComments", false) as boolean;
     if (echoFullWorkItem) {
       StateFullWorkItemInStream(
         stream,

--- a/src/github/gitHubUtils.ts
+++ b/src/github/gitHubUtils.ts
@@ -8,7 +8,7 @@ export function parseGitHubValuesFromPrompt(
   stream: vscode.ChatResponseStream
 ) {
   const match = request.prompt.match(issueNumberRegex);
-  const [itemId, commentsUsage] = match ? [match[1], match[2]] : ["", ""];
+  const [itemId, commentsUsage] = match ? [match[1], match[2] === '+'] : ["", false];
 
   stream.progress(`Item #${itemId} found in prompt.`);
   const ghMatch = request.prompt.match(ghRepoRegex);

--- a/src/github/issues/GitHubIssuesPrompt.tsx
+++ b/src/github/issues/GitHubIssuesPrompt.tsx
@@ -7,7 +7,7 @@ import {
 } from "@vscode/prompt-tsx";
 import {
   getIssueAndCommentsById,
-  StateFullIssueInStream,
+  StateFullGHIssueInStream,
 } from "./gitHubIssueFunctions";
 import { ASSISTANT_MESSAGE, OPEN_URL_COMMAND } from "../../consts";
 import type { GitHubResult } from "../GitHubResult";
@@ -39,10 +39,10 @@ export class GitHubIssuesPrompt extends PromptElement<
 
     // Access vscode settings
     const config = vscode.workspace.getConfiguration("voce");
-    const echoFullIssue = config.get("echoFullIssue", false) as boolean;
-    const echoIssueComments = config.get("echoIssueComments", false) as boolean;
+    const echoFullIssue = config.get("echoFullGHIssue", false) as boolean;
+    const echoIssueComments = config.get("echoGHIssueComments", false) as boolean;
     if (echoFullIssue) {
-      StateFullIssueInStream(
+      StateFullGHIssueInStream(
         stream,
         ghResult?.data!,
         echoIssueComments ? ghResult?.comments ?? [] : []

--- a/src/github/issues/GitHubIssuesPrompt.tsx
+++ b/src/github/issues/GitHubIssuesPrompt.tsx
@@ -32,7 +32,7 @@ export class GitHubIssuesPrompt extends PromptElement<
       Number(itemId),
       ghOwner,
       ghRepo,
-      commentsUsage === "+"
+      commentsUsage
     )) as GitHubResult;
 
     stream.progress(`🟣Issue "${ghResult?.data?.title}" loaded.`);

--- a/src/github/issues/gitHubIssueFunctions.ts
+++ b/src/github/issues/gitHubIssueFunctions.ts
@@ -4,7 +4,7 @@ import { determineGhOwnerAndRepoToUse } from "../gitHub";
 import { type GitHubComment } from "../GitHubComment";
 import { type GitHubResult } from "../GitHubResult";
 
-export function StateFullIssueInStream(
+export function StateFullGHIssueInStream(
   stream: vscode.ChatResponseStream,
   issue: { title: string; body: string },
   comments: GitHubComment[]

--- a/src/github/pullrequests/GitHubPullrequestPrompt.tsx
+++ b/src/github/pullrequests/GitHubPullrequestPrompt.tsx
@@ -8,7 +8,7 @@ import {
 import { ASSISTANT_MESSAGE, OPEN_URL_COMMAND } from "../../consts";
 import {
   getGhPullrequestById as getGhPullrequestById,
-  StateFullPrInStream,
+  StateFullGhPrInStream,
 } from "./gitHubPullrequestFunctions";
 import { parseGitHubValuesFromPrompt } from "../gitHubUtils";
 import type { GitHubResult } from "../GitHubResult";
@@ -44,11 +44,11 @@ export class GitHubPullrequestPrompt extends PromptElement<
           ? ghResult.comments.map((comment: any) => `○ ${comment.body}`).join("\n\n")
           : "";
 
-        StateFullPrInStream(stream, ghResult?.data!, commentsString);
+        StateFullGhPrInStream(stream, ghResult?.data!, commentsString);
       }
       else
       {
-        StateFullPrInStream(stream, ghResult?.data!);
+        StateFullGhPrInStream(stream, ghResult?.data!);
       }
     } 
     else {

--- a/src/github/pullrequests/GitHubPullrequestPrompt.tsx
+++ b/src/github/pullrequests/GitHubPullrequestPrompt.tsx
@@ -7,7 +7,7 @@ import {
 } from "@vscode/prompt-tsx";
 import { ASSISTANT_MESSAGE, OPEN_URL_COMMAND } from "../../consts";
 import {
-  getPullrequestById,
+  getGhPullrequestById as getGhPullrequestById,
   StateFullPrInStream,
 } from "./gitHubPullrequestFunctions";
 import { parseGitHubValuesFromPrompt } from "../gitHubUtils";
@@ -24,23 +24,34 @@ export class GitHubPullrequestPrompt extends PromptElement<
     const { request, stream } = requestHandlerContext;
     const { ghOwner, ghRepo, itemId, commentsUsage } = parseGitHubValuesFromPrompt(request, stream);
 
-    const ghResult = (await getPullrequestById(
+    const ghResult = (await getGhPullrequestById(
       requestHandlerContext,
       Number(itemId),
       ghOwner,
       ghRepo,
-      commentsUsage === "+"
+      commentsUsage
     )) as GitHubResult;
 
     stream.progress(`PR "${ghResult?.data?.title}" loaded.`);
 
-    // Access vscode settings
     const config = vscode.workspace.getConfiguration("voce");
     const echoFullGHPullRequest = config.get("echoFullGHPullRequest", false) as boolean;
-    const echoIssueComments = config.get("echoGhPullRequestComments", false) as boolean;
+    const echoGHPullRequestComments = config.get("echoGhPullRequestComments", false) as boolean;
     if (echoFullGHPullRequest) {
-      StateFullPrInStream(stream, ghResult?.data!);
-    } else {
+      if (echoGHPullRequestComments)
+      {
+        const commentsString = ghResult?.comments
+          ? ghResult.comments.map((comment: any) => comment.body).join("\n\n")
+          : "";
+          
+        StateFullPrInStream(stream, ghResult?.data!, commentsString);
+      }
+      else
+      {
+        StateFullPrInStream(stream, ghResult?.data!, null);
+      }
+    } 
+    else {
       stream.markdown(
         `🔵PR [_${ghResult.data?.state}_]: **${ghResult.data?.title}**\n\n`
       );
@@ -64,11 +75,10 @@ export class GitHubPullrequestPrompt extends PromptElement<
         <UserMessage priority={200}>
           {`The pullrequest to work on has the title: "${ghResult?.data?.title}" and the description: ${ghResult?.data?.body}. Use that information to give better answer for the following user query.` +
             (ghResult?.comments && ghResult?.comments?.length > 0
-              ? `Do also regard the comments: ${
-                  ghResult?.comments
-                    ?.map((comment) => comment.body)
-                    .join("\n\n") + ""
-                }`
+              ? `Do also regard the comments: ${ghResult?.comments
+                ?.map((comment) => comment.body)
+                .join("\n\n") + ""
+              }`
               : "")}
         </UserMessage>
         <UserMessage priority={100}>{userPrompt}</UserMessage>

--- a/src/github/pullrequests/GitHubPullrequestPrompt.tsx
+++ b/src/github/pullrequests/GitHubPullrequestPrompt.tsx
@@ -41,7 +41,7 @@ export class GitHubPullrequestPrompt extends PromptElement<
       if (echoGHPullRequestComments)
       {
         const commentsString = ghResult?.comments
-          ? ghResult.comments.map((comment: any) => comment.body).join("\n\n")
+          ? ghResult.comments.map((comment: any) => `○ ${comment.body}`).join("\n\n")
           : "";
 
         StateFullPrInStream(stream, ghResult?.data!, commentsString);

--- a/src/github/pullrequests/GitHubPullrequestPrompt.tsx
+++ b/src/github/pullrequests/GitHubPullrequestPrompt.tsx
@@ -7,7 +7,7 @@ import {
 } from "@vscode/prompt-tsx";
 import { ASSISTANT_MESSAGE, OPEN_URL_COMMAND } from "../../consts";
 import {
-  getGhPullrequestById as getGhPullrequestById,
+  getGhPullrequestById,
   StateFullGhPrInStream,
 } from "./gitHubPullrequestFunctions";
 import { parseGitHubValuesFromPrompt } from "../gitHubUtils";

--- a/src/github/pullrequests/GitHubPullrequestPrompt.tsx
+++ b/src/github/pullrequests/GitHubPullrequestPrompt.tsx
@@ -36,7 +36,7 @@ export class GitHubPullrequestPrompt extends PromptElement<
 
     const config = vscode.workspace.getConfiguration("voce");
     const echoFullGHPullRequest = config.get("echoFullGHPullRequest", false) as boolean;
-    const echoGHPullRequestComments = config.get("echoGhPullRequestComments", false) as boolean;
+    const echoGHPullRequestComments = config.get("echoGHPullRequestComments", false) as boolean;
     if (echoFullGHPullRequest) {
       if (echoGHPullRequestComments)
       {

--- a/src/github/pullrequests/GitHubPullrequestPrompt.tsx
+++ b/src/github/pullrequests/GitHubPullrequestPrompt.tsx
@@ -43,7 +43,7 @@ export class GitHubPullrequestPrompt extends PromptElement<
         const commentsString = ghResult?.comments
           ? ghResult.comments.map((comment: any) => comment.body).join("\n\n")
           : "";
-          
+
         StateFullPrInStream(stream, ghResult?.data!, commentsString);
       }
       else
@@ -73,9 +73,9 @@ export class GitHubPullrequestPrompt extends PromptElement<
       <>
         <AssistantMessage priority={300}>{ASSISTANT_MESSAGE}</AssistantMessage>
         <UserMessage priority={200}>
-          {`The pullrequest to work on has the title: "${ghResult?.data?.title}" and the description: ${ghResult?.data?.body}. Use that information to give better answer for the following user query.` +
+          {`The GitHub pullrequest to work on has the title: "${ghResult?.data?.title}" and the description: ${ghResult?.data?.body}. Use that information to give better answer for the following user query.` +
             (ghResult?.comments && ghResult?.comments?.length > 0
-              ? `Do also regard the comments: ${ghResult?.comments
+              ? `Do also consider the comments: ${ghResult?.comments
                 ?.map((comment) => comment.body)
                 .join("\n\n") + ""
               }`

--- a/src/github/pullrequests/GitHubPullrequestPrompt.tsx
+++ b/src/github/pullrequests/GitHubPullrequestPrompt.tsx
@@ -48,7 +48,7 @@ export class GitHubPullrequestPrompt extends PromptElement<
       }
       else
       {
-        StateFullPrInStream(stream, ghResult?.data!, null);
+        StateFullPrInStream(stream, ghResult?.data!);
       }
     } 
     else {

--- a/src/github/pullrequests/gitHubPullrequestFunctions.ts
+++ b/src/github/pullrequests/gitHubPullrequestFunctions.ts
@@ -6,7 +6,7 @@ import {
 import { type GitHubComment } from "../GitHubComment";
 import { type GitHubResult } from "../GitHubResult";
 
-export function StateFullPrInStream(
+export function StateFullGhPrInStream(
   stream: vscode.ChatResponseStream,
   pullrequest: { title: string; body: string; state: string },
   comments: string | null = null

--- a/src/github/pullrequests/gitHubPullrequestFunctions.ts
+++ b/src/github/pullrequests/gitHubPullrequestFunctions.ts
@@ -8,15 +8,21 @@ import { type GitHubResult } from "../GitHubResult";
 
 export function StateFullPrInStream(
   stream: vscode.ChatResponseStream,
-  pullrequest: { title: string; body: string }
+  pullrequest: { title: string; body: string; state: string },
+  comments: string | null = null
 ) {
-  stream.markdown(`🔵PR: **${pullrequest.title}**\n\n`);
+  stream.markdown(`🔵PR [_${pullrequest.state}_]: **${pullrequest.title}**\n\n`);
   stream.markdown(pullrequest.body?.replaceAll("\n", "\n> ") + "");
+  stream.markdown("\n\n");
+  if (comments && comments.length > 0) {
+    stream.markdown(`> **Comments:**\n\n`);
+    stream.markdown(comments.replaceAll("\n", "\n> ") + "");
+  }
   stream.markdown("\n\n----\n\n");
 }
 
 //get issue object from github by its issue id using octokit
-export async function getPullrequestById(
+export async function getGhPullrequestById(
   requestHandlerContext: RequestHandlerContext,
   pull_number: number,
   ghOwner: string = "",


### PR DESCRIPTION
This pull request introduces changes to improve the handling of pull requests and work items for both Azure DevOps and GitHub. The updates focus on enhancing comments handling, improving naming consistency, and streamlining the code for better readability and functionality.

### Azure DevOps Updates:
* **Refactored comments usage handling:** Updated `commentsUsage` to be a boolean instead of a string, simplifying its usage throughout the codebase. (`src/azd/azDevOpsUtils.ts`, `src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx`, `src/azd/workitems/AzDevOpsWorkItemsPrompt.tsx`) [[1]](diffhunk://#diff-39172188e89b79d2771d14932a25ac1f850915ef9b5cbe6735fa4d7a77b58cdeL13-R17) [[2]](diffhunk://#diff-310ead2ac60bc3474c8e3042e531e8feaeae87e2d7aa0c9b6d484394b89573cfL27-R60) [[3]](diffhunk://#diff-18672f49cece96990058073e735583c94b7bdc67b6a7b0bc78453c7ae62d6e4bL35-R35)
* **Enhanced pull request rendering:** Added support for displaying comments in the pull request markdown output when the `echoAzDPullRequestComments` setting is enabled. (`src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx`, `src/azd/pullrequests/azDevOpsPullrequestFunctions.ts`) [[1]](diffhunk://#diff-310ead2ac60bc3474c8e3042e531e8feaeae87e2d7aa0c9b6d484394b89573cfL27-R60) [[2]](diffhunk://#diff-aa88c0f92a81cf72529f6aae97ab998f2aa957325f2f28425b232831521b2b92L13-R24)

### GitHub Updates:
* **Refactored comments usage handling:** Similar to Azure DevOps, updated `commentsUsage` to be a boolean for simplicity. (`src/github/gitHubUtils.ts`, `src/github/issues/GitHubIssuesPrompt.tsx`, `src/github/pullrequests/GitHubPullrequestPrompt.tsx`) [[1]](diffhunk://#diff-2ad2a7ef80f3a799bf3e2059abd50d71dbeefa84476938a9fa5d88b38267cde4L11-R11) [[2]](diffhunk://#diff-2f6937143d4775cfc091410a393d94c67dd400e2c52007ede2d932a203b07c81L35-R35) [[3]](diffhunk://#diff-ca1adc3bb0701e4a7aa9cfa6b66bc5ffd525fb83c32de03d1bfd36e67b96bf30L27-R54)
* **Enhanced pull request rendering:** Added support for displaying comments in the pull request markdown output when the `echoGhPullRequestComments` setting is enabled. (`src/github/pullrequests/GitHubPullrequestPrompt.tsx`, `src/github/pullrequests/gitHubPullrequestFunctions.ts`) [[1]](diffhunk://#diff-ca1adc3bb0701e4a7aa9cfa6b66bc5ffd525fb83c32de03d1bfd36e67b96bf30L27-R54) [[2]](diffhunk://#diff-23f8ada5799ec8dc110e5779e6fbe3180ba6048e68ffb888f7a8a518a5ea377bL9-R25)

### General Improvements:
* **Renamed functions for clarity:** Updated function names to include specific prefixes (`getAzdPullrequestById`, `StateFullAzDPrInStream`, `getGhPullrequestById`, `StateFullGhPrInStream`) for better differentiation between Azure DevOps and GitHub implementations. (`src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx`, `src/azd/pullrequests/azDevOpsPullrequestFunctions.ts`, `src/github/pullrequests/GitHubPullrequestPrompt.tsx`, `src/github/pullrequests/gitHubPullrequestFunctions.ts`) [[1]](diffhunk://#diff-310ead2ac60bc3474c8e3042e531e8feaeae87e2d7aa0c9b6d484394b89573cfL10-R11) [[2]](diffhunk://#diff-aa88c0f92a81cf72529f6aae97ab998f2aa957325f2f28425b232831521b2b92L84-R90) [[3]](diffhunk://#diff-ca1adc3bb0701e4a7aa9cfa6b66bc5ffd525fb83c32de03d1bfd36e67b96bf30L10-R11) [[4]](diffhunk://#diff-23f8ada5799ec8dc110e5779e6fbe3180ba6048e68ffb888f7a8a518a5ea377bL9-R25)
* **Improved user-facing text:** Updated phrasing for better clarity in comments-related messages (e.g., "Do also consider the comments" instead of "Do also regard the comments"). (`src/azd/pullrequests/AzDevOpsPullrequestPrompt.tsx`, `src/github/pullrequests/GitHubPullrequestPrompt.tsx`) [[1]](diffhunk://#diff-310ead2ac60bc3474c8e3042e531e8feaeae87e2d7aa0c9b6d484394b89573cfL71-R85) [[2]](diffhunk://#diff-ca1adc3bb0701e4a7aa9cfa6b66bc5ffd525fb83c32de03d1bfd36e67b96bf30L65-R78)