### PR TITLE
Update dependabot-issue-bundler.md

### DIFF
--- a/.github/workflows/dependabot-issue-bundler.md
+++ b/.github/workflows/dependabot-issue-bundler.md
@@ -11,6 +11,13 @@ permissions:
 tools:
   github:
 
+network:
+  allowed:
+    - defaults              # Basic infrastructure
+    - python               # Python/PyPI ecosystem
+    - node                 # Node.js/NPM ecosystem
+    - "learn.microsoft.com:443"
+
 safe-outputs:
   create-issue:
     title-prefix: '[dependabot-bundler] '


### PR DESCRIPTION
This pull request updates the workflow configuration to explicitly allow network access to specific domains and ecosystems, improving security and clarity for dependency management automation.

Network permissions update:

* [`.github/workflows/dependabot-issue-bundler.md`](diffhunk://#diff-e2dd8ef04ac16574f37ac92afcf2497bcb86600ee362e851f9e2ae73d6c646ceR14-R20): Added an `allowed` list under the `network` section to specify permitted network targets, including defaults, Python/PyPI, Node.js/NPM, and `learn.microsoft.com:443`.